### PR TITLE
Changed to di, and fixed getting token

### DIFF
--- a/Blazor/Shared/Login.razor
+++ b/Blazor/Shared/Login.razor
@@ -1,4 +1,6 @@
-﻿<h3>Login</h3>
+﻿@inject AccountServiceManager AccountServiceManager
+
+<h3>Login</h3>
 
 
 <p>
@@ -10,7 +12,7 @@
     <Input type="text" id="password" value="@utilisateur.password" />
 </p>
 
-<button value="Sign in" @onclick="connect" />
+<button value="Sign in" @onclick="connect" >Login</button>
 
 <div>
     @connected
@@ -19,14 +21,14 @@
 @code {
     @using SmartMailBoxLib.Models
     @using SmartMailBoxLib.Services
-
-    IAccountService accountService = AccountServiceManager.GetAccountService();
+    
     IUtilisateurService utilisateurService = UtilisateurServiceManager.GetUtilisateurService();
     Utilisateur utilisateur = new Utilisateur();
     string connected = "";
    
     async void connect()
     {
+        IAccountService accountService = AccountServiceManager.GetAccountService();
         utilisateur.email = "admin@contejonathan.net";
         utilisateur.password = "mydil34000";
         await accountService.Login(utilisateur);
@@ -34,5 +36,4 @@
         connected = utilisateurWithError.t.lastName;
 
     }
-
 }

--- a/Blazor/Startup.cs
+++ b/Blazor/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using SmartMailBoxLib;
 
 namespace Blazor
 {
@@ -7,6 +8,7 @@ namespace Blazor
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSmartMailboc();
         }
 
         public void Configure(IComponentsApplicationBuilder app)

--- a/SmartMailBoxLib/Models/Constants.cs
+++ b/SmartMailBoxLib/Models/Constants.cs
@@ -12,8 +12,8 @@ namespace SmartMailBoxLib.Models
         public static readonly Color MainTextColor = Color.Black;
         public static readonly int LoginIconHeight = 120;
 
-        //private static readonly string RouteBase = "https://smartmailbox-epsi.herokuapp.com";
-        private static string RouteBase = "http://192.168.1.17:8080";
+        private static readonly string RouteBase = "https://smartmailbox-epsi.herokuapp.com";
+        //private static string RouteBase = "http://192.168.1.17:8080";
 
         #region url api
         //login connexion

--- a/SmartMailBoxLib/REST/RestService.cs
+++ b/SmartMailBoxLib/REST/RestService.cs
@@ -11,51 +11,39 @@ using Ninject;
 
 namespace SmartMailBoxLib.REST
 {
-    internal class RestService
+    public class RestService
     {
-        [Inject]
         protected HttpClient _client { get; set; }
         
         private static RestService instance = null;
         private static readonly object padlock = new object();
 
-        RestService()
+        public RestService(HttpClient httpClient)
         {
-            _client = new HttpClient();
+            //_client = new HttpClient();
+            _client = httpClient;
             _client.BaseAddress = new Uri(Constants.BaseAdresse);
             _client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-        }
-
-        public static RestService Instance
-        {
-            get
-            {
-                lock (padlock)
-                {
-                    if (instance == null)
-                    {
-                        instance = new RestService();
-                    }
-                    return instance;
-                }
-            }
         }
 
         public void Logout()
         {
             instance = null;
-            _client = null;
+            _client = null;  //You probablly dont want to do this
         }
 
-        public string PostReponseLogin(string url, Utilisateur utilisateur)
+        public async Task<string> PostReponseLogin(string url, Utilisateur utilisateur)
         {
+            Console.WriteLine(_client.ToString());
             string token = null;
             const string contentType = "application/json";
 
             string jsonstring = JsonConvert.SerializeObject(utilisateur);
             jsonstring = jsonstring ?? "";
+            Console.WriteLine("jsonstring: " + jsonstring);
             var httpContent = new StringContent(jsonstring, Encoding.UTF8, contentType);
-            var result = _client.PostAsync(url, httpContent).Result;
+            var result = await _client.PostAsync(url, httpContent);
+
             var jsonResult = result.Content.ReadAsStringAsync().Result;
             token = jsonResult;
 

--- a/SmartMailBoxLib/ServiceCollectionExtensions.cs
+++ b/SmartMailBoxLib/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using SmartMailBoxLib.REST;
+using SmartMailBoxLib.Services;
+
+namespace SmartMailBoxLib
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddSmartMailboc(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton<RestService>();
+            serviceCollection.AddScoped<AccountServiceManager>();
+            serviceCollection.AddScoped<AccountServiceApi>();
+            return serviceCollection;
+        }
+    }
+}

--- a/SmartMailBoxLib/Services/Account/AccountServiceApi.cs
+++ b/SmartMailBoxLib/Services/Account/AccountServiceApi.cs
@@ -12,32 +12,36 @@ namespace SmartMailBoxLib.Services
 {
     public class AccountServiceApi : IAccountService
     {
+        private RestService _restService;
         
-        public AccountServiceApi()
+        public AccountServiceApi(RestService restService)
         {
+            _restService = restService;
         }
 
         //Login api avec token
         public async Task<string> Login(Utilisateur utilisateur)
         {
-            string response = RestService.Instance.PostReponseLogin(Constants.LoginUrl, utilisateur);
-            RestService.Instance.AddBearerTokenToHeader(response);
+            Console.WriteLine(Constants.LoginUrl);
+            string response = await _restService.PostReponseLogin(Constants.LoginUrl, utilisateur);
+            Console.WriteLine(response);
+            _restService.AddBearerTokenToHeader(response);
             return response;
         }
 
         public GenericObjectWithErrorModel<string> PostForgotPassword(string pUsername)
         {
-            return RestService.Instance.PostReponse<string>(Constants.ForgotPassword, pUsername);
+            return _restService.PostReponse<string>(Constants.ForgotPassword, pUsername);
         }
 
         public GenericObjectWithErrorModel<Utilisateur> PostCreateAccount(Utilisateur _utilisateur)
         {
-            return RestService.Instance.PostReponse<Utilisateur>(Constants.RegisterUtilisateur, JsonConvert.SerializeObject(_utilisateur));
+            return _restService.PostReponse<Utilisateur>(Constants.RegisterUtilisateur, JsonConvert.SerializeObject(_utilisateur));
         }
 
         public void Logout()
         {
-            RestService.Instance.Logout();
+            _restService.Logout();
         }
 
     }

--- a/SmartMailBoxLib/Services/Account/AccountServiceManager.cs
+++ b/SmartMailBoxLib/Services/Account/AccountServiceManager.cs
@@ -1,21 +1,25 @@
 ﻿using System;
+using System.Net.Http;
 using SmartMailBoxLib.Models;
 
 namespace SmartMailBoxLib.Services
 {
     public class AccountServiceManager
     {
-        public AccountServiceManager()
+        private readonly AccountServiceApi _accountServiceApi;
+
+        public AccountServiceManager(AccountServiceApi accountServiceApi)
         {
+            _accountServiceApi = accountServiceApi;
         }
 
-        public static IAccountService GetAccountService()
+        public IAccountService GetAccountService()
         {
             IAccountService accountService;
             if (Constants.IsMocked)
                 accountService = new AccountServiceMocked();
             else
-                accountService = new AccountServiceApi();
+                accountService = _accountServiceApi;
 
             return accountService;
         }

--- a/SmartMailBoxLib/Services/Account/AccountServiceMocked.cs
+++ b/SmartMailBoxLib/Services/Account/AccountServiceMocked.cs
@@ -9,6 +9,7 @@ namespace SmartMailBoxLib.Services
 {
     public class AccountServiceMocked : IAccountService
     {
+        private RestService _restService; //TODO !
         public AccountServiceMocked()
         {
         }
@@ -16,7 +17,7 @@ namespace SmartMailBoxLib.Services
         public async Task<string> Login(Utilisateur utilisateur)
         {
             string response = "TokenMocked";
-            RestService.Instance.AddBearerTokenToHeader(response);
+            _restService.AddBearerTokenToHeader(response);
             return response;
         }
 
@@ -37,7 +38,7 @@ namespace SmartMailBoxLib.Services
 
         public void Logout()
         {
-            RestService.Instance.Logout();
+            _restService.Logout();
         }
     }
 }

--- a/SmartMailBoxLib/Services/BoiteAuLettre/BoiteAuLettreServiceApi.cs
+++ b/SmartMailBoxLib/Services/BoiteAuLettre/BoiteAuLettreServiceApi.cs
@@ -7,18 +7,20 @@ namespace SmartMailBoxLib.Services
 {
     public class BoiteAuLettreServiceApi : IBoiteAuLettreService
     {
+        private RestService _restService; //TODO !
+
         public BoiteAuLettreServiceApi()
         {
         }
 
         public GenericObjectWithErrorModel<BoiteAuLettre> PostCreateBoiteAuLettre(BoiteAuLettre boiteAuLettre)
         {
-            return RestService.Instance.PostReponse<BoiteAuLettre>(Constants.CreateBAL, JsonConvert.SerializeObject(boiteAuLettre));
+            return _restService.PostReponse<BoiteAuLettre>(Constants.CreateBAL, JsonConvert.SerializeObject(boiteAuLettre));
         }
 
         public GenericObjectWithErrorModel<Utilisateur> PutAjoutBoiteToUtilisateur(BoiteAuLettre boiteAuLettre)
         {
-            return RestService.Instance.PostReponse<Utilisateur>(Constants.AddBalToCurrentUser, JsonConvert.SerializeObject(boiteAuLettre));
+            return _restService.PostReponse<Utilisateur>(Constants.AddBalToCurrentUser, JsonConvert.SerializeObject(boiteAuLettre));
         }
     }
 }

--- a/SmartMailBoxLib/Services/Courrier/CourrierServiceApi.cs
+++ b/SmartMailBoxLib/Services/Courrier/CourrierServiceApi.cs
@@ -6,13 +6,14 @@ namespace SmartMailBoxLib.Services
 {
     public class CourrierServiceApi : ICourrierService
     {
+        private RestService _restService; //TODO !
         public CourrierServiceApi()
         {
         }
 
         public GenericObjectWithErrorModel<Models.Courrier> PutCourrierVu(int pId)
         {
-            return RestService.Instance.PutResponse<Models.Courrier>(String.Format(Constants.UpdateCourrierBybyId, pId), null);
+            return _restService.PutResponse<Models.Courrier>(String.Format(Constants.UpdateCourrierBybyId, pId), null);
         }
     }
 }

--- a/SmartMailBoxLib/Services/Utilisateur/UtilisateurServiceApi.cs
+++ b/SmartMailBoxLib/Services/Utilisateur/UtilisateurServiceApi.cs
@@ -6,18 +6,20 @@ namespace SmartMailBoxLib.Services
 {
     public class UtilisateurServiceApi : IUtilisateurService
     {
+        private RestService _restService; //TODO !
+
         public UtilisateurServiceApi()
         {
         }
 
         public GenericObjectWithErrorModel<Utilisateur> GetUtilisateurConnectedWithErrorModel()
         {
-            return RestService.Instance.GetResponse<GenericObjectWithErrorModel<Utilisateur>>(Constants.UtilisateurConnected);
+            return _restService.GetResponse<GenericObjectWithErrorModel<Utilisateur>>(Constants.UtilisateurConnected);
         }
 
         public GenericObjectWithErrorModel<Utilisateur> PutInformationsPersonnelles(Utilisateur utilisateurUpdated)
         {
-            return RestService.Instance.PutResponse<Utilisateur>(Constants.UpdateUser, JsonConvert.SerializeObject(utilisateurUpdated));
+            return _restService.PutResponse<Utilisateur>(Constants.UpdateUser, JsonConvert.SerializeObject(utilisateurUpdated));
         }
     }
 }

--- a/SmartMailBoxLib/SmartMailBoxLib.csproj
+++ b/SmartMailBoxLib/SmartMailBoxLib.csproj
@@ -17,6 +17,7 @@
     <Compile Remove="Class1.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Ninject" Version="3.3.4" />
   </ItemGroup>


### PR DESCRIPTION
*started* to change the code to be DI firendly - I did it quick so its a bit sloppy, you will want to use interface where I used concrete classes, that way you will be able to hide your implantation of RestServce for example (I had to make it public).

Only did AccountManager - the rest will be broken.

The actual error fix though is in RestService You forgot an await on PostAsync - That also means the return becomes Task<string> instead of string.

Now, when you login, you will get a token in the console (I added a few Console.WriteLine's you will want to remove) - but there is an error after that, didn't check to see what it was.

